### PR TITLE
Deprecate np.str and np.int attributes & handles reading potential energy

### DIFF
--- a/simple_nn/features/symmetry_function/generating.py
+++ b/simple_nn/features/symmetry_function/generating.py
@@ -287,7 +287,10 @@ def _extract_EFS(inputs, structure, logfile, comm):
     # TODO: other formats
     else:
         if structure.calc is not None:
-            E = structure.get_potential_energy(force_consistent=True)
+            try:
+                E = structure.get_potential_energy(force_consistent=True)
+            except:
+                E = structure.get_potential_energy()
 
         if inputs['data']['read_force'] is True:
             try:

--- a/simple_nn/models/neural_network.py
+++ b/simple_nn/models/neural_network.py
@@ -53,11 +53,11 @@ class FCNDict(torch.nn.Module):
                 with open(inputs['params'][item], 'r') as f:
                     tmp = f.readlines()
                 input_dim = len(tmp) #open params read input number of symmetry functions
-                FIL.write('scale1 {}\n'.format(' '.join(np.zeros(input_dim).astype(np.str))))
-                FIL.write('scale2 {}\n'.format(' '.join(np.ones(input_dim).astype(np.str))))
+                FIL.write('scale1 {}\n'.format(' '.join(np.zeros(input_dim).astype(str))))
+                FIL.write('scale2 {}\n'.format(' '.join(np.ones(input_dim).astype(str))))
             else:
-                FIL.write('scale1 {}\n'.format(' '.join(scale_factor[item][0].cpu().numpy().astype(np.str))))
-                FIL.write('scale2 {}\n'.format(' '.join(scale_factor[item][1].cpu().numpy().astype(np.str))))
+                FIL.write('scale1 {}\n'.format(' '.join(scale_factor[item][0].cpu().numpy().astype(str))))
+                FIL.write('scale2 {}\n'.format(' '.join(scale_factor[item][1].cpu().numpy().astype(str))))
 
             # An extra linear layer is used for PCA transformation.
             nodes   = list()
@@ -86,7 +86,7 @@ class FCNDict(torch.nn.Module):
                     pca_mean /= pca[item][1].cpu().numpy()
 
                 for k in range(pca[item][0].cpu().numpy().shape[1]):
-                    FIL.write('w{} {}\n'.format(k, ' '.join(pca_mat[:,k].astype(np.str))))
+                    FIL.write('w{} {}\n'.format(k, ' '.join(pca_mat[:,k].astype(str))))
                     FIL.write('b{} {}\n'.format(k, -pca_mean[k]))
 
             for j in range(nlayers):
@@ -99,7 +99,7 @@ class FCNDict(torch.nn.Module):
                 FIL.write('LAYER {} {}\n'.format(j+joffset, acti))
 
                 for k in range(nodes[j + joffset]):
-                    FIL.write('w{} {}\n'.format(k, ' '.join(weights[j][k,:].astype(np.str))))
+                    FIL.write('w{} {}\n'.format(k, ' '.join(weights[j][k,:].astype(str))))
                     FIL.write('b{} {}\n'.format(k, biases[j][k]))
 
             FIL.write('\n')

--- a/simple_nn/utils/scale.py
+++ b/simple_nn/utils/scale.py
@@ -48,7 +48,7 @@ def uniform_gas(inputs, feature_list, atom_type, comm):
     recvbuf = np.zeros(inp_size)
 
     count = comm.allgather(count)
-    displ = np.zeros(comm.size, dtype=np.int)
+    displ = np.zeros(comm.size, dtype=int)
     for i in range(1, comm.size):
         displ[i] = displ[i - 1] + count[i - 1]
 


### PR DESCRIPTION
Deprecate np.str and np.int attributes & handle reading potential energy in a different format than VASP