### PR TITLE
Update the readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,5 +18,13 @@ formats:
   - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.7'
+
+
+
 python:
-  version: 3.7
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/quick_tutorial/quick_tutorial.rst
+++ b/docs/quick_tutorial/quick_tutorial.rst
@@ -81,6 +81,9 @@ If you want to see which data are saved in ``.pt`` file, use the following comma
 
 ``result`` provides the information of input features as dictionary format.
 
+.. warning::
+    It is recommended to turn on the ``calc_pca`` and ``calc_scale`` options in the ``preprocess``, without which the root-mean-square-error (RMSE) can be high in the ``training``.
+
 .. _training:
 
 Training
@@ -115,6 +118,9 @@ The 70-30-30-1 network is optimized by Adam optimizer with the 0.001 of learning
 The input feature vectors whose size is 70 are converted by ``scale_factor``, following PCA matrix transformation by ``pca``
 The execution log and energy, force, and stress root-mean-squared-error (RMSE) are stored in ``LOG``. 
 Input files introduced in this section can be found in ``SIMPLE-NN/tutorials/Training``.
+
+
+  
 
 .. _evaluation:
 

--- a/docs/quick_tutorial/quick_tutorial.rst
+++ b/docs/quick_tutorial/quick_tutorial.rst
@@ -82,7 +82,7 @@ If you want to see which data are saved in ``.pt`` file, use the following comma
 ``result`` provides the information of input features as dictionary format.
 
 .. warning::
-    It is recommended to turn on the ``calc_pca`` and ``calc_scale`` options in the ``preprocess``, without which the root-mean-square-error (RMSE) can be high in the ``training``.
+    We strongly recommend turning on the ``calc_pca`` and ``calc_scale`` options in the ``preprocess``. They significantly reduce the root-mean-square-error (RMSE) in the ``training``.
 
 .. _training:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
Updated  .readthedocs.yml due to depreciated format and to work well in the readthedocs.

Reference : https://blog.readthedocs.com/migrate-configuration-v2/ 

Add warning about PCA and scale in preprocess.  