### PR TITLE
Enabling setup.py installation in Windows (Following issue #113, #88)

### DIFF
--- a/simple_nn/features/symmetry_function/SIMD/pair_nn_simd_function.h
+++ b/simple_nn/features/symmetry_function/SIMD/pair_nn_simd_function.h
@@ -1,6 +1,14 @@
 #include <immintrin.h>
 #include <algorithm>
+#ifdef _WIN32
+#include <cmath>
+inline void sincos(double x, double* sinx, double* cosx){
+    *sinx = sin(x);
+    *cosx = cos(x);   
+}
+#else
 #include <math.h>
+#endif
 #include "mkl.h"
 #include <assert.h>
 

--- a/simple_nn/features/symmetry_function/symmetry_functions.h
+++ b/simple_nn/features/symmetry_function/symmetry_functions.h
@@ -1,5 +1,13 @@
 #define _USE_MATH_DEFINES
+#ifdef _WIN32
+#include <cmath>
+inline void sincos(double x, double* sinx, double* cosx){
+    *sinx = sin(x);
+    *cosx = cos(x);   
+}
+#else
 #include <math.h>
+#endif
 /*
  Code for calculate symmetry function.
  This code is used for both Python and LAMMPS code


### PR DESCRIPTION
  - Added OS detection in the files that use sincos function, which is not supported in Windows by default.
  - The function 'sincos' is defined if the detected OS is Windows.
  - Otherwise it runs the existing code